### PR TITLE
Save the height and width of an ndarray image in load_img in PST

### DIFF
--- a/phycv/pst.py
+++ b/phycv/pst.py
@@ -25,6 +25,7 @@ class PST:
         """
         if img_array is not None:
             self.img = img_array
+            self.h, self.w = self.img.shape[:2]
         else:
             self.img = cv2.imread(img_file)
             if not self.h and not self.w:


### PR DESCRIPTION
## Issue description
In the `PST` class if one calls the `__init__` method without passing the height `h` and width `w`, and then calls `load_img` with an ndarray, the height and width of the image won't be saved. Consequently, `init_kernel` will throw an error because it needs `self.h` and `self.w` but they are `None`.

## Solution
Solution is simply to set `self.h` and `self.w` when loading the image from a ndarray. This fixes the error above.