### PR TITLE
save height and width when loading image array directly

### DIFF
--- a/phycv/page.py
+++ b/phycv/page.py
@@ -28,6 +28,8 @@ class PAGE:
         if img_array is not None:
             # directly load the image from numpy array
             self.img = img_array
+            self.h = img_array.shape[0]
+            self.w = img_array.shape[1]
         else:
             # load the image from the image file
             self.img = cv2.imread(img_file)

--- a/phycv/pst.py
+++ b/phycv/pst.py
@@ -25,6 +25,8 @@ class PST:
         """
         if img_array is not None:
             self.img = img_array
+            self.img = img_array.shape[0]
+            self.img = img_array.shape[1]
         else:
             self.img = cv2.imread(img_file)
             if not self.h and not self.w:

--- a/phycv/vevid.py
+++ b/phycv/vevid.py
@@ -26,6 +26,8 @@ class VEVID:
         if img_array is not None:
             # directly load the image from numpy array
             self.img_bgr = img_array
+            self.h = img_array.shape[0]
+            self.w = img_array.shape[1]
         else:
             # load the image from the image file
             self.img_bgr = cv2.imread(img_file)


### PR DESCRIPTION
For CPU versions, when directly loading the image array, the width and height should be saved as mentioned in #10 